### PR TITLE
Only collection the Ftrack version when the task is available.

### DIFF
--- a/pyblish_bumpybox/plugins/ftrack/collect_ftrack_version.py
+++ b/pyblish_bumpybox/plugins/ftrack/collect_ftrack_version.py
@@ -13,6 +13,9 @@ class CollectFtrackVersion(pyblish.api.ContextPlugin):
         session = context.data["ftrackSession"]
         task = context.data["ftrackTask"]
 
+        if not task:
+            return
+
         query = "select versions.version from Asset where parent.id is \"{0}\""
         query += " and type.short is \"scene\" and name is \"{1}\""
         asset = session.query(query.format(


### PR DESCRIPTION
With recent efforts to support NukeStudio, its possible to not have launched from a task, hence preventing the plugin in failing.