### PR TITLE
Sort the context by the instance family and then the instance name.

### DIFF
--- a/pyblish_bumpybox/plugins/collect_sorting.py
+++ b/pyblish_bumpybox/plugins/collect_sorting.py
@@ -9,5 +9,7 @@ class CollectSorting(pyblish.api.Collector):
     def process(self, context):
 
         context[:] = sorted(
-            context, key=lambda instance: (instance.data["name"])
+            context, key=lambda instance: (
+                instance.data("family"), instance.data("name")
+            )
         )


### PR DESCRIPTION
This gives a better overview on the instances, when there are different kinds of instance types.

Pyblish-qml displays this best with its sections in the instance list.