### PR TITLE
Allow collections to not have a version when collecting existing files.

### DIFF
--- a/pyblish_bumpybox/plugins/collect_existing_files.py
+++ b/pyblish_bumpybox/plugins/collect_existing_files.py
@@ -15,12 +15,9 @@ class CollectExistingFiles(pyblish.api.ContextPlugin):
     label = "Existing Files"
     hosts = ["maya", "houdini", "nuke"]
 
-    scanned_dirs = []
-    files = []
-
-    def version_get(self, string, prefix):
+    def get_version(self, string, prefix):
         """ Extract version information from filenames.  Code from Foundry"s
-        nukescripts.version_get()
+        nukescripts.get_version()
         """
 
         if string is None:
@@ -34,43 +31,49 @@ class CollectExistingFiles(pyblish.api.ContextPlugin):
             return None
         return matches[-1:][0][1], re.search("\d+", matches[-1:][0]).group()
 
-    def scan_versions(self, instance_collection, version):
+    def get_version_collections(self, collection, version):
+        """Return all collections of previous collection versions."""
 
-        # Getting collections of all previous versions and current version
         collections = []
         for count in range(1, int(version) + 1):
-
-            # Generate collection
             version_string = "v" + str(count).zfill(len(version))
-            head = instance_collection.head.replace(
+            head = collection.head.replace(
                 "v" + version, version_string
             )
-            collection = clique.Collection(
+
+            version_collection = clique.Collection(
                 head=head.replace("\\", "/"),
-                padding=instance_collection.padding,
-                tail=instance_collection.tail
+                padding=collection.padding,
+                tail=collection.tail
             )
-            collection.version = count
-
-            collection = self.scan_collection(collection)
-
-            if list(collection):
-                collections.append(collection)
+            version_collection.name = collection.name
+            version_collection.label = collection.label
+            version_collection.family = collection.family
+            version_collection.version = count
+            version_collection.nodes = collection.nodes
+            collections.append(version_collection)
 
         return collections
 
-    def scan_collection(self, collection):
+    def scan_collections_files(self, collections):
+        """Return all files in the directories of the collections."""
 
-        # Scan collection directory
-        scan_dir = os.path.dirname(collection.head)
-        if scan_dir not in self.scanned_dirs and os.path.exists(scan_dir):
-            for f in os.listdir(scan_dir):
-                file_path = os.path.join(scan_dir, f)
-                self.files.append(file_path.replace("\\", "/"))
-            self.scanned_dirs.append(scan_dir)
+        scanned_dirs = []
+        files = []
+        for collection in collections:
+            scan_dir = os.path.dirname(collection.head)
+            if scan_dir not in scanned_dirs and os.path.exists(scan_dir):
+                for f in os.listdir(scan_dir):
+                    file_path = os.path.join(scan_dir, f)
+                    files.append(file_path.replace("\\", "/"))
+                scanned_dirs.append(scan_dir)
 
-        # Match files to collection and add
-        for f in self.files:
+        return files
+
+    def match_files_collection(self, files, collection):
+        """Match files to collection and return filled collection."""
+
+        for f in files:
             if collection.match(f):
                 collection.add(f)
 
@@ -78,59 +81,70 @@ class CollectExistingFiles(pyblish.api.ContextPlugin):
 
     def process(self, context):
 
-        # Validate instance based on support families.
+        # Gather all valid collections
         valid_families = ["img", "cache", "scene", "mov"]
-        valid_instances = []
+        collections = []
         for instance in context:
             families = instance.data.get("families", [])
             family_type = list(set(families) & set(valid_families))
-            if family_type:
-                valid_instances.append(instance)
 
-        # Create existing output instance.
-        for instance in valid_instances:
-            instance_collection = instance.data.get("collection", None)
-
-            if not instance_collection:
+            if not family_type:
                 continue
 
-            version = self.version_get(
-                os.path.basename(instance_collection.format()), "v"
+            collection = instance.data.get("collection", None)
+
+            if not collection:
+                continue
+
+            collection.indexes.clear()
+
+            # Store instance data on collection for later usage
+            collection.name = instance.data["name"]
+            collection.label = instance.data["label"]
+            collection.family = family_type[0]
+            collection.version = context.data["version"]
+            collection.nodes = instance[:]
+
+            # Get older version collections
+            version = self.get_version(
+                os.path.basename(collection.format()), "v"
+            )
+            if version:
+                collections.extend(
+                    self.get_version_collections(
+                        collection, version[1]
+                    )
+                )
+
+            # Ensure original collection is gathered
+            if collection not in collections:
+                collections.append(collection)
+
+        files = self.scan_collections_files(collections)
+
+        # Generate instances from collections
+        for collection in collections:
+
+            collection = self.match_files_collection(
+                files, collection
             )
 
-            collections = []
-            if version:
-                collections = self.scan_versions(
-                    instance_collection, version[1]
-                )
-            else:
-                collection = self.scan_collection(instance_collection)
-                if list(collection):
-                    collections.append(collection)
+            if not list(collection):
+                continue
 
-            if collections:
-                families = set(valid_families) & set(instance.data["families"])
-                for collection in collections:
-                    name = instance.data["name"]
-                    new_instance = instance.context.create_instance(name=name)
+            instance = context.create_instance(name=collection.name)
 
-                    label = instance.data["label"].split("-")[0] + "- "
-                    fmt = "{head}{padding}{tail}"
-                    label += os.path.basename(collection.format(fmt))
-                    label += collection.format(" [{ranges}]")
-                    new_instance.data["label"] = label
+            label = collection.label.split("-")[0] + "- "
+            fmt = "{head}{padding}{tail}"
+            label += os.path.basename(collection.format(fmt))
+            label += collection.format(" [{ranges}]")
+            instance.data["label"] = label
 
-                    new_instance.data["families"] = list(families)
-                    new_instance.data["family"] = "output"
-                    new_instance.data["publish"] = False
-                    new_instance.data["collection"] = collection
+            instance.data["families"] = [collection.family]
+            instance.data["family"] = "output"
+            instance.data["publish"] = False
+            instance.data["collection"] = collection
+            instance.data["version"] = collection.version
 
-                    # If the collection does not have a version,
-                    # we'll take the context version.
-                    if hasattr(collection, "version"):
-                        new_instance.data["version"] = collection.version
-                    else:
-                        new_instance.data["version"] = context.data["version"]
-
-                    for node in instance:
-                        new_instance.add(node)
+            for node in collection.nodes:
+                instance.add(node)

--- a/pyblish_bumpybox/plugins/collect_existing_files.py
+++ b/pyblish_bumpybox/plugins/collect_existing_files.py
@@ -70,7 +70,7 @@ class CollectExistingFiles(pyblish.api.ContextPlugin):
 
         return files
 
-    def populate_collection(self, files, collection):
+    def populate_collection(self, collection, files):
         """Match and add files to collection.
 
         Returns populated collection.
@@ -129,7 +129,7 @@ class CollectExistingFiles(pyblish.api.ContextPlugin):
         for collection in collections:
 
             collection = self.populate_collection(
-                files, collection
+                collection, files
             )
 
             if not list(collection):

--- a/pyblish_bumpybox/plugins/collect_existing_files.py
+++ b/pyblish_bumpybox/plugins/collect_existing_files.py
@@ -70,8 +70,11 @@ class CollectExistingFiles(pyblish.api.ContextPlugin):
 
         return files
 
-    def match_files_collection(self, files, collection):
-        """Match files to collection and return filled collection."""
+    def populate_collection(self, files, collection):
+        """Match and add files to collection.
+
+        Returns populated collection.
+        """
 
         for f in files:
             if collection.match(f):
@@ -125,7 +128,7 @@ class CollectExistingFiles(pyblish.api.ContextPlugin):
         # Generate instances from collections
         for collection in collections:
 
-            collection = self.match_files_collection(
+            collection = self.populate_collection(
                 files, collection
             )
 


### PR DESCRIPTION
Previously when scanning for existing files, an error would occur when there was no version number in the collections file name.
This will allow collections to not be forced to have version numbers in the file name.

This was spawned by working on the NukeStudio workflow where collections of transcoded images doesn't not have a version number in the file name.