### PR TITLE
Further distinguish the source scene from other scenes.

### DIFF
--- a/pyblish_bumpybox/plugins/collect_scene.py
+++ b/pyblish_bumpybox/plugins/collect_scene.py
@@ -22,7 +22,7 @@ class CollectScene(pyblish.api.ContextPlugin):
         instance = context.create_instance(name=os.path.basename(current_file))
 
         instance.data["families"] = ["scene"]
-        instance.data["family"] = "scene"
+        instance.data["family"] = "source"
         instance.data["path"] = current_file
         label = "{0} - scene".format(os.path.basename(current_file))
         instance.data["label"] = label


### PR DESCRIPTION
Before the plugin just added the "scene" family twice, and there were no further distinction between the source scene and other scenes.