### PR TITLE
Sort by label rather than name.

### DIFF
--- a/pyblish_bumpybox/plugins/collect_sorting.py
+++ b/pyblish_bumpybox/plugins/collect_sorting.py
@@ -10,6 +10,6 @@ class CollectSorting(pyblish.api.Collector):
 
         context[:] = sorted(
             context, key=lambda instance: (
-                instance.data("family"), instance.data("name")
+                instance.data("family"), instance.data("label")
             )
         )


### PR DESCRIPTION
As this plugin is purely for visual clarity in the GUIs, we should sort by the label instead of the name,