### PR TITLE
extract_json log level

### DIFF
--- a/pyblish_bumpybox/plugins/extract_json.py
+++ b/pyblish_bumpybox/plugins/extract_json.py
@@ -40,7 +40,7 @@ class ExtractJSON(pyblish.api.ContextPlugin):
                     msg = "\"{0}\"".format(value)
                     msg += " in instance.data[\"{0}\"]".format(key)
                     msg += " could not be serialized."
-                    self.log.warning(msg)
+                    self.log.debug(msg)
 
             output_data.append(data)
 


### PR DESCRIPTION
Reduce log level of json extraction, due to warnings are visible in pyblish-qml