### PR TITLE
Backdrop nodes

### DIFF
--- a/docs/nuke.md
+++ b/docs/nuke.md
@@ -7,6 +7,7 @@ Output Format | Section
 Image Sequence | [Write Node](#write-node)
 Gizmo | [Group](#group)
 LUT | [Group](#group)
+Nuke Script | [Backdrop](#backdrop)
 
 ## Write Node
 
@@ -27,6 +28,10 @@ Disabling a write node will disable it for publishing. Similarly if you disable 
 To publish a gizmo, you'll need to setup a group. Please read about creating groups [here](http://help.thefoundry.co.uk/nuke/8.0/content/user_guide/configuring_nuke/creating_sourcing_gizmos.html)
 
 To publish a LUT, you'll need to setup a group. Please read the ```To Create a Viewer Process Gizmo``` section [here](http://help.thefoundry.co.uk/nuke/8.0/content/user_guide/configuring_nuke/using_gizmo_viewer_process.html)
+
+## Backdrop
+
+To publish a subset of nodes to a Nuke script, you'll need to setup a backdrop node. All nodes within the backdrop will be available for publishing.
 
 ## Remote Rendering/Processing
 

--- a/pyblish_bumpybox/plugins/nuke/collect_nuke_backdrops.py
+++ b/pyblish_bumpybox/plugins/nuke/collect_nuke_backdrops.py
@@ -1,0 +1,53 @@
+import pyblish.api
+
+
+class CollectNukeBackdrops(pyblish.api.ContextPlugin):
+    """Collect all backdrop nodes.
+
+    Offset to get context.data["currentFile"]
+    """
+
+    order = pyblish.api.CollectorOrder + 0.1
+    label = "Backdrops"
+    hosts = ["nuke"]
+
+    def process(self, context):
+        import os
+        import nuke
+
+        # creating instances per backdrop node
+        for node in nuke.allNodes():
+            if node.Class() != "BackdropNode":
+                continue
+
+            name = node["name"].getValue()
+            instance = context.create_instance(name=name)
+            instance.add(node)
+
+            instance.data["families"] = ["local", "backdrop"]
+            instance.data["family"] = "scene"
+
+            label = "{0} - {1} - {2}".format(name, "scene", "local")
+            instance.data["label"] = label
+
+            # Adding/Checking publish attribute
+            instance.data["publish"] = False
+            if "publish" not in node.knobs():
+                knob = nuke.Boolean_Knob("publish", "Publish")
+                knob.setValue(False)
+                node.addKnob(knob)
+            else:
+                instance.data["publish"] = node["publish"].getValue()
+
+            # Generate output path
+            directory = os.path.join(
+                os.path.dirname(instance.context.data["currentFile"]),
+                "workspace"
+            )
+            scene_name = os.path.splitext(
+                os.path.basename(instance.context.data["currentFile"])
+            )[0]
+            instance.data["output_path"] = os.path.join(
+                directory,
+                "{0}_{1}.nk".format(scene_name, instance.data["name"])
+            )

--- a/pyblish_bumpybox/plugins/nuke/extract_nuke_backdrop.py
+++ b/pyblish_bumpybox/plugins/nuke/extract_nuke_backdrop.py
@@ -1,0 +1,46 @@
+import pyblish.api
+
+
+class ExtractNukeBackdrop(pyblish.api.InstancePlugin):
+    """ Extract gizmos from group nodes. """
+
+    order = pyblish.api.ExtractorOrder
+    optional = True
+    families = ["backdrop"]
+    label = "Backdrop"
+    hosts = ["nuke"]
+
+    def process(self, instance):
+        import os
+        import nuke
+
+        if not instance.data["publish"]:
+            return
+
+        file_path = instance.data["output_path"]
+        directory = os.path.dirname(file_path)
+
+        # Create workspace if necessary
+        if not os.path.exists(directory):
+            os.makedirs(directory)
+
+        # Export gizmo
+        # Deselect all nodes
+        for node in nuke.selectedNodes():
+            node["selected"].setValue(False)
+
+        instance[0]["selected"].setValue(True)
+        for node in instance[0].getNodes():
+            node["selected"].setValue(True)
+
+        nuke.nodeCopy(file_path)
+
+        data = ""
+        with open(file_path, "r") as f:
+            data = f.read()
+
+        data = data.replace("set cut_paste_input [stack 0]\n", "")
+        data = data.replace("push $cut_paste_input\n", "")
+
+        with open(file_path, "w") as f:
+            f.write(data)


### PR DESCRIPTION
**Motivation**

This makes it easy to publish a subset of nodes within a Nuke script. Unlike gizmos that can't be edited, a subset of nodes can be tweaked at the artists will.

**Testing**

1. Create a some nodes in Nuke, then select them all and create a backdrop.
2. When publishing backdrop node will be available for extraction.