### PR TITLE
Change workspace file name to include write node name and separate in scene name folders.

### DIFF
--- a/pyblish_bumpybox/plugins/nuke/validate_nuke_write_node.py
+++ b/pyblish_bumpybox/plugins/nuke/validate_nuke_write_node.py
@@ -89,7 +89,7 @@ class ValidateNukeWriteNode(pyblish.api.InstancePlugin):
             "{nuke.thisNode().name()}]/[python {os.path.splitext("
             "os.path.basename(nuke.scriptName()))[0]}]/[python {"
             "os.path.splitext(os.path.basename(nuke.scriptName()))[0]}]_"
-            "[python {nuke.thisNode().name()}].%04d.exr"
+            "[python {nuke.thisNode().name()}]"
         )
 
         # Default padding starting at 4 digits.

--- a/pyblish_bumpybox/plugins/nuke/validate_nuke_write_node.py
+++ b/pyblish_bumpybox/plugins/nuke/validate_nuke_write_node.py
@@ -86,9 +86,9 @@ class ValidateNukeWriteNode(pyblish.api.InstancePlugin):
 
         expected = (
             "[python {nuke.script_directory()}]/workspace/[python "
-            "{os.path.splitext(os.path.basename(nuke.scriptName()))[0]}]/"
-            "[python {nuke.thisNode().name()}]/[python "
-            "{os.path.splitext(os.path.basename(nuke.scriptName()))[0]}]_"
+            "{nuke.thisNode().name()}]/[python {os.path.splitext("
+            "os.path.basename(nuke.scriptName()))[0]}]/[python {"
+            "os.path.splitext(os.path.basename(nuke.scriptName()))[0]}]_"
             "[python {nuke.thisNode().name()}].%04d.exr"
         )
 

--- a/pyblish_bumpybox/plugins/nuke/validate_nuke_write_node.py
+++ b/pyblish_bumpybox/plugins/nuke/validate_nuke_write_node.py
@@ -84,10 +84,12 @@ class ValidateNukeWriteNode(pyblish.api.InstancePlugin):
 
     def get_expected_value(self, instance):
 
-        expected = "[python {nuke.script_directory()}]/workspace/"
-        expected += "[python {nuke.thisNode()[\"name\"].getValue()}]/"
-        expected += "[python {os.path.splitext(os.path.basename("
-        expected += "nuke.scriptName()))[0]}]"
+        expected = (
+            "[python {nuke.script_directory()}]/workspace/[python "
+            "{nuke.thisNode()[\"name\"].getValue()}]/[python "
+            "{os.path.splitext(os.path.basename(nuke.scriptName()))[0]}]_"
+            "[python {nuke.thisNode()[\"name\"].getValue()}]"
+        )
 
         # Default padding starting at 4 digits.
         padding = 4

--- a/pyblish_bumpybox/plugins/nuke/validate_nuke_write_node.py
+++ b/pyblish_bumpybox/plugins/nuke/validate_nuke_write_node.py
@@ -86,9 +86,10 @@ class ValidateNukeWriteNode(pyblish.api.InstancePlugin):
 
         expected = (
             "[python {nuke.script_directory()}]/workspace/[python "
-            "{nuke.thisNode()[\"name\"].getValue()}]/[python "
+            "{os.path.splitext(os.path.basename(nuke.scriptName()))[0]}]/"
+            "[python {nuke.thisNode().name()}]/[python "
             "{os.path.splitext(os.path.basename(nuke.scriptName()))[0]}]_"
-            "[python {nuke.thisNode()[\"name\"].getValue()}]"
+            "[python {nuke.thisNode().name()}].%04d.exr"
         )
 
         # Default padding starting at 4 digits.


### PR DESCRIPTION
**Motivation**

When reading the output of a write node into a Nuke script, you can only see the scene name, which can make it hard to get an overview of which write node the output came from.

**Changes**

Before:

![old](https://user-images.githubusercontent.com/1860085/29622508-ed58b5d8-8823-11e7-9507-5319b43ad868.PNG)


After:

![new](https://user-images.githubusercontent.com/1860085/29622510-ef4c8be4-8823-11e7-90f9-ffd7e1a4d078.PNG)


**Testing**

1. Create a write node and set the file name and extension.
2. Publish the write node and notice the validated output path.

The validation of the nuke write node will handle changing the path is there are old write node in the script.
