### PR TITLE
Initial commit of collecting Read nodes for publishing.

### DIFF
--- a/pyblish_bumpybox/plugins/ftrack/collect_ftrack_nuke_reads.py
+++ b/pyblish_bumpybox/plugins/ftrack/collect_ftrack_nuke_reads.py
@@ -19,6 +19,10 @@ class CollectFtrackNukeReads(pyblish.api.ContextPlugin):
             if node.Class() != "Read":
                 continue
 
+            # Ignore asset Read nodes
+            if "assetVersionId" in node.knobs():
+                continue
+
             # Determine output type
             output_type = "img"
             movie_formats = ["ari", "avi", "gif", "mov", "r3d"]

--- a/pyblish_bumpybox/plugins/ftrack/collect_ftrack_nuke_reads.py
+++ b/pyblish_bumpybox/plugins/ftrack/collect_ftrack_nuke_reads.py
@@ -1,0 +1,63 @@
+import os
+
+import nuke
+import pyblish.api
+import clique
+
+
+class CollectFtrackNukeReads(pyblish.api.ContextPlugin):
+    """Collect all read nodes."""
+
+    order = pyblish.api.CollectorOrder
+    label = "Reads"
+    hosts = ["nuke"]
+
+    def process(self, context):
+
+        # creating instances per write node
+        for node in nuke.allNodes():
+            if node.Class() != "Read":
+                continue
+
+            # Determine output type
+            output_type = "img"
+            movie_formats = ["ari", "avi", "gif", "mov", "r3d"]
+            if node.metadata()["input/filereader"] in movie_formats:
+                output_type = "mov"
+
+            # Create instance
+            instance = context.create_instance(node.name())
+            instance.data["families"] = [output_type, "local", "output"]
+            instance.data["family"] = "read"
+            instance.add(node)
+
+            path = nuke.filename(node)
+            instance.data["label"] = "{0} - {1}".format(
+                node.name(), os.path.basename(path)
+            )
+
+            # Adding/Checking publish attribute
+            instance.data["publish"] = False
+            if "publish" not in node.knobs():
+                knob = nuke.Boolean_Knob("publish", "Publish")
+                knob.setValue(False)
+                node.addKnob(knob)
+            else:
+                instance.data["publish"] = node["publish"].getValue()
+
+            # Collecting file paths
+            if output_type == "img":
+                # This could be improved because it does not account for "#"
+                # being in a sequence.
+                if "#" in path:
+                    padding = path.count("#")
+                    path = path.replace(
+                        "#" * padding, "%{0:0>2}d".format(padding)
+                    )
+
+                first_frame = int(node["first"].getValue())
+                last_frame = int(node["last"].getValue())
+                path += " [{0}-{1}]".format(first_frame, last_frame)
+                instance.data["collection"] = clique.parse(path)
+            else:
+                instance.data["output_path"] = path

--- a/pyblish_bumpybox/plugins/ftrack/collect_ftrack_nuke_reads.py
+++ b/pyblish_bumpybox/plugins/ftrack/collect_ftrack_nuke_reads.py
@@ -41,13 +41,12 @@ class CollectFtrackNukeReads(pyblish.api.ContextPlugin):
             )
 
             # Adding/Checking publish attribute
-            instance.data["publish"] = False
             if "publish" not in node.knobs():
                 knob = nuke.Boolean_Knob("publish", "Publish")
                 knob.setValue(False)
                 node.addKnob(knob)
-            else:
-                instance.data["publish"] = node["publish"].getValue()
+
+            instance.data["publish"] = bool(node["publish"].getValue())
 
             # Collecting file paths
             if output_type == "img":


### PR DESCRIPTION
**Motivation**

The use case for this is if the footage is needed to be ingested into Ftrack.

Previously you would have to transcode the images into the workspace in order to publish it to Ftrack. This simplifies the workflow and reduces the time for publishing to Ftrack.

**Changes**

Introduced a new collector for getting the read nodes.

**Testing**

1. Launch Nuke.
2. Create a Read node.
3. Enable the publish of the read node in the GUI.
