### PR TITLE
Adding family to valid search types.

### DIFF
--- a/pyblish_bumpybox/plugins/collect_existing_files.py
+++ b/pyblish_bumpybox/plugins/collect_existing_files.py
@@ -89,6 +89,7 @@ class CollectExistingFiles(pyblish.api.ContextPlugin):
         collections = []
         for instance in context:
             families = instance.data.get("families", [])
+            families += [instance.data["family"]]
             family_type = list(set(families) & set(valid_families))
 
             if not family_type:


### PR DESCRIPTION
**Motivation**

The ```family``` data member was not included when comparing the families to the valid types of families for collecting existing files from.
