### PR TITLE
Wrong publish data member type.

### DIFF
--- a/pyblish_bumpybox/plugins/nuke/collect_nuke_backdrops.py
+++ b/pyblish_bumpybox/plugins/nuke/collect_nuke_backdrops.py
@@ -31,13 +31,12 @@ class CollectNukeBackdrops(pyblish.api.ContextPlugin):
             instance.data["label"] = label
 
             # Adding/Checking publish attribute
-            instance.data["publish"] = False
             if "publish" not in node.knobs():
                 knob = nuke.Boolean_Knob("publish", "Publish")
                 knob.setValue(False)
                 node.addKnob(knob)
-            else:
-                instance.data["publish"] = node["publish"].getValue()
+
+            instance.data["publish"] = bool(node["publish"].getValue())
 
             # Generate output path
             directory = os.path.join(

--- a/pyblish_bumpybox/plugins/nuke/collect_nuke_groups.py
+++ b/pyblish_bumpybox/plugins/nuke/collect_nuke_groups.py
@@ -36,13 +36,12 @@ class CollectNukeGroups(pyblish.api.ContextPlugin):
                 instance.data["label"] = label
 
                 # Adding/Checking publish attribute
-                instance.data["publish"] = False
                 if fmt not in node.knobs():
                     knob = nuke.Boolean_Knob(fmt, fmt.title())
                     knob.setValue(False)
                     node.addKnob(knob)
-                else:
-                    instance.data["publish"] = node[fmt].getValue()
+
+                instance.data["publish"] = bool(node[fmt].getValue())
 
                 # Generate output path
                 directory = os.path.join(

--- a/pyblish_bumpybox/plugins/nuke/collect_nuke_writes.py
+++ b/pyblish_bumpybox/plugins/nuke/collect_nuke_writes.py
@@ -45,7 +45,7 @@ class CollectNukeWrites(pyblish.api.ContextPlugin):
             label = "{0} - write - {1}"
             instance.data["label"] = label.format(node.name(), process_place)
 
-            instance.data["publish"] = not node["disable"].getValue()
+            instance.data["publish"] = bool(not node["disable"].getValue())
 
             # Get frame range
             start_frame = int(nuke.root()["first_frame"].getValue())


### PR DESCRIPTION
**Motivation**

Getting float values from Nuke checkbox knobs were resulting in always evaulating True for the "publish" data member.

This does not affect the publish when going through the UI because the UI has its own mechanism for determining whether an instance is in a publishable state.
This is also the reason why this has not been caught earlier, since it only affects publishing in the background with ```pyblish.util.publish```

**Testing**

1. Create two write nodes.
2. Disable one of the write nodes.
3. Execute ```pyblish.util.publish()```.

This should fail both write nodes when validating for a Crop node, although only one write node should be published.